### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Install
 
-    $ npm install -g repl.it
+    $ npm install -g repl.sh
 
 ## Usage
   


### PR DESCRIPTION
the correct npm package is `repl.sh`, but the current README instructs users to run:

`npm i -g repl.it`